### PR TITLE
Chat Vod Synchronisation

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -200,9 +200,9 @@ body {
 }
 
 #chat-stream {
-	height: -moz-calc(100% - 48px);
-	height: -webkit-calc(100% - 48px);
-	height: calc(100% - 48px);
+	height: -moz-calc(100%);
+	height: -webkit-calc(100%);
+	height: calc(100%);
 	font-size: 13px;
 	padding: 10px;
 	color: #EEEEEE;
@@ -267,51 +267,6 @@ body {
 .skip-message {
 	background-color: #222;
 	padding: 10px;
-}
-
-/* Chat Controls */
-
-#chat-controls {
-	height: 48px;
-}
-
-#non-skip-controls {
-	height: 100%;
-	display: flex;
-	justify-content: space-around;
-	align-items: center;
-	color: white;
-}
-
-#skip-controls {
-	height: 100%;
-	display: none;
-	justify-content: space-around;
-	align-items: center;
-	color: white;
-}
-
-#skip-time-input {
-	height: 24px;
-	width: 100px;
-	text-align: center;
-	font-family: 'Ubuntu Mono', monospace;
-}
-
-#chat-controls .octicon {
-	font-size: 32px;
-}
-
-#play-button {
-	display: none;
-}
-
-#play-button, #stop-button, #skip-view-button, #back-button, #skip-button {
-	cursor: pointer;
-} 
-
-#chat-time {
-	font-family: 'Ubuntu Mono', monospace;
 }
 
 /* Scroll Bar Style */

--- a/public/index.html
+++ b/public/index.html
@@ -68,19 +68,6 @@
 			<div id="video-player"></div>
 			<div id="chat-container">
 				<div id="chat-stream"></div>
-				<div id="chat-controls">
-					<div id="non-skip-controls">
-						<span title="Play" id="play-button" class="octicon octicon-triangle-right tooltip"></span>
-						<span title="Stop" id="stop-button" class="octicon octicon-primitive-square tooltip"></span>
-						<span class="tooltip" title="Chat Time" id="chat-time">00:00:00</span>
-						<span title="Skip to Time" id="skip-view-button" class="octicon octicon-chevron-right tooltip"></span>
-					</div>
-					<div id="skip-controls">
-						<span title="Back" id="back-button" class="octicon octicon-arrow-left tooltip"></span>
-						<input type="text" id="skip-time-input" placeholder="00:00:00" />
-						<span title="Skip to Time" id="skip-button" class="octicon octicon-chevron-right tooltip"></span>
-					</div>
-				</div>
 			</div>
 		</div>
 	</div>

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,7 +1,10 @@
-var Chat = function(id) {
+var Chat = function(id, player) {
 	this.videoId = id;
 	this.status = "loading";
 	this.skipView = false;
+	this.videoPlayer = player;
+	this.chatDelay = 8;
+	this.previousTimeOffset = -1;
 
 	var self = this;
 
@@ -127,14 +130,15 @@ var Chat = function(id) {
 
 	window.setInterval(function() {
 		if (self.status == "running" && self.chat) {
-			var utcFormat = self.currentTime.format().replace("+00:00", "Z");
-			if (self.chat[utcFormat]) {
+			//var utcFormat = self.currentTime.format().replace("+00:00", "Z");
+			var currentTimeOffset = Math.floor(self.videoPlayer.getCurrentTime());
+			var utcFormat = self.recordedTime.clone().add(self.chatDelay + currentTimeOffset, 's').format().replace("+00:00", "Z");
+			if (currentTimeOffset != self.previousTimeOffset && self.chat[utcFormat]) {
 				self.chat[utcFormat].forEach(function(chatLine) {
 					$("#chat-stream").append("<div class='chat-line'>" + 
 						"<span class='username'>" + 
 						chatLine.username + "</span>: " + 
-						"<span class='message'>" + 
-						self._formatMessage(chatLine.message) + "</span></div>");
+						"<span class='message'>"+ self._formatMessage(chatLine.message) + "</span></div>");
 				});
 
 				$("#chat-stream").animate({ 
@@ -142,12 +146,7 @@ var Chat = function(id) {
 				}, 1000);
 			}
 
-			self.currentTime.add(1, 's');
-			$("#chat-time").text(self._formatTime(self.currentTime - self.recordedTime));
-
-			if (!self.skipView) {
-				$("#skip-time-input").val(self._formatTime(self.currentTime - self.recordedTime));
-			}
+			self.previousTimeOffset = currentTimeOffset;
 		}
 	}, 1000);
 };

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -10,7 +10,6 @@ var Chat = function(id, player) {
 
 	$.get("https://api.twitch.tv/kraken/videos/" + id + "?client_id=88bxd2ntyahw9s8ponrq2nwluxx17q", function(vodData) {
 		self.recordedTime = moment(vodData.recorded_at).utc();
-		self.currentTime = self.recordedTime.clone();
 
 		// http://dgg.overrustlelogs.net/Destinygg chatlog/March 2016/2016-03-23
 		var overrustleLogsUrl = "http://dgg.overrustlelogs.net/Destinygg%20chatlog/" + 
@@ -28,61 +27,12 @@ var Chat = function(id, player) {
 		});
 	});
 
-	$("#play-button").click(function() {
-		self.startChatStream();
-	});
-
-	$("#stop-button").click(function() {
-		self.pauseChatStream();
-	});
-
-	$("#skip-view-button").click(function() {
-		self.skipView = true;
-		$("#non-skip-controls").hide();
-		$("#skip-controls").css("display", "flex");
-		$("#skip-time-input").focus().select();
-	});
-
-	$("#back-button").click(function() {
-		self.skipView = false;
-		$("#skip-controls").hide();
-		$("#non-skip-controls").css("display", "flex");
-	});
-
-	$("#skip-button").click(function() {
-		if (self._skipToTime($("#skip-time-input").val())) {
-			self.skipView = false;
-			$("#skip-controls").hide();
-			$("#non-skip-controls").css("display", "flex");
-		}
-	});
-
 	this.startChatStream = function() {
-		$("#play-button").hide();
-		$("#stop-button").show();
 		this.status = "running";
 	};
 
 	this.pauseChatStream = function() {
-		$("#stop-button").hide();
-		$("#play-button").show();
 		this.status = "paused";
-	};
-
-	this._skipToTime = function(timeString) {
-		var timeValues = timeString.match(/(.*):(.*):(.*)/);
-
-		if (timeValues === null) {
-			return false;
-		}
-
-		self.currentTime = self.recordedTime.clone()
-												.add(timeValues[1], 'h')
-												.add(timeValues[2], 'm')
-												.add(timeValues[3], 's');
-		$("#chat-stream").append("<div class='skip-message'>Skipping to " + timeString + "...</div>");
-
-		return true;
 	};
 
 	this._formatMessage = function(message) {
@@ -130,7 +80,6 @@ var Chat = function(id, player) {
 
 	window.setInterval(function() {
 		if (self.status == "running" && self.chat) {
-			//var utcFormat = self.currentTime.format().replace("+00:00", "Z");
 			var currentTimeOffset = Math.floor(self.videoPlayer.getCurrentTime());
 			var utcFormat = self.recordedTime.clone().add(self.chatDelay + currentTimeOffset, 's').format().replace("+00:00", "Z");
 			if (currentTimeOffset != self.previousTimeOffset && self.chat[utcFormat]) {
@@ -138,7 +87,8 @@ var Chat = function(id, player) {
 					$("#chat-stream").append("<div class='chat-line'>" + 
 						"<span class='username'>" + 
 						chatLine.username + "</span>: " + 
-						"<span class='message'>"+ self._formatMessage(chatLine.message) + "</span></div>");
+						"<span class='message'>" +
+					        self._formatMessage(chatLine.message) + "</span></div>");
 				});
 
 				$("#chat-stream").animate({ 

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -80,7 +80,7 @@ var loadPlayer = function(id) {
     $("#player").css("display", "flex");
 
     var player = new Twitch.Player("video-player", { video: id });
-    var chat = new Chat(id);
+    var chat = new Chat(id, player);
 
     player.addEventListener("play", function() {
         chat.startChatStream();


### PR DESCRIPTION
Synchronised chat to the current vod time by polling getCurrentTime() for the embedded video and offsetting the time with the start time.

The chat time controls were not needed as the chat is always synchronised to the video so they were removed.

The timestamps from OverRustleLogs don't exactly sync up with the timing of the vod so an 8 second delay is added to the chat to better sync up chat reactions with the content of the video.